### PR TITLE
Remove tests/ from sdist build - it is currently too big

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune tests


### PR DESCRIPTION
Removes the `tests/` directory from sdist when running `python -m build` because `tests/` is a bit too large and complex to distribute with our source code in pypi.

This adds a MANIFEST.in file exclusively pruning the directory from builds.

Might want to reconsider this if we clean things up in tests/.