### PR TITLE
Fix bug by allowing emission_scenarios to be None

### DIFF
--- a/src/dscim/menu/simple_storage.py
+++ b/src/dscim/menu/simple_storage.py
@@ -37,7 +37,7 @@ class Climate:
         Period for rebasing FAIR temperature anomalies. This should match the CIL projection system's base period.
     emission_scenarios: list or None, optional
         List of emission scenarios for which SCC will be calculated. Default
-        is ["ssp119", "ssp126", "ssp245", "ssp460", "ssp370", "ssp585"].
+        is (), which gets set to ["ssp119", "ssp126", "ssp245", "ssp460", "ssp370", "ssp585"].
     gases: list or None, optional
         List of greenhouse gases for which SCC will be calculated. Default is
         ["CO2_Fossil", "CH4", "N2O"].


### PR DESCRIPTION
Fix #45 by allowing `emission_scenarios` to be `None` without modifying its value during instantiation. This allows dscim-epa to replicate prior results and should allow for the [update_dscim](https://github.com/ClimateImpactLab/dscim-epa/tree/update_dscim) branch in `dscim-epa` to be merged.