### PR TITLE
Pin GH Actions Python to 3.10 for h5py

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.x"]
+        python-version: ["3.10"]
     defaults:
       run:
         shell: bash
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.x"]
+        python-version: ["3.10"]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Pinning CI runs to Python 3.10 because `h5py` doesn't appear to have built support for Python 3.11 and this is a dependency for testing.

This change should be reverted once we are able to either drop h5py or pypi h5py can run with Python 3.11.