### PR TITLE
Fix damage function paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove old/unnecessary files. ([PR #57](https://github.com/ClimateImpactLab/dscim/pull/57), [@JMGilbert](https://github.com/JMGilbert))
 - Remove unused “save_path” and “ec_cls” from `read_energy_files_parallel()`. ([PR #56](https://github.com/ClimateImpactLab/dscim/pull/56), [@davidrzhdu](https://github.com/davidrzhdu))
 ### Fixed
+- Make rff damage functions read in and save out in the proper filepath structure. ([PR #79](https://github.com/ClimateImpactLab/dscim/pull/79), [@JMGilbert](https://github.com/JMGilbert))
 - Enter the proper functional form of isoelastic utility when `eta = 1`. ([PR #65](https://github.com/ClimateImpactLab/dscim/pull/65), [@JMGilbert](https://github.com/JMGilbert))
 - Pin numpy version to stop tests failing. ([PR #60](https://github.com/ClimateImpactLab/dscim/pull/60), [@JMGilbert](https://github.com/JMGilbert))
 

--- a/src/dscim/utils/rff.py
+++ b/src/dscim/utils/rff.py
@@ -320,6 +320,7 @@ def weight_df(
     factors,
     pulse_year,
     fractional=False,
+    mask="unmasked",
 ):
     """Weight, fractionalize, and combine SSP damage functions,
     then multiply by RFF GDP to return RFF damage functions.
@@ -328,7 +329,7 @@ def weight_df(
     # get damage function as share of global GDP
     df = (
         xr.open_dataset(
-            f"{in_library}/{sector}/{pulse_year}/{recipe}_{disc}_eta{eta_rho[0]}_rho{eta_rho[1]}_{file}.nc4"
+            f"{in_library}/{sector}/{pulse_year}/{mask}/{recipe}_{disc}_eta{eta_rho[0]}_rho{eta_rho[1]}_{file}.nc4"
         )
         / ssp_gdp
     )
@@ -339,7 +340,7 @@ def weight_df(
     # save fractional damage function
     if fractional:
         rff.sel(year=slice(2020, 2099)).to_netcdf(
-            f"{out_library}/{sector}/{pulse_year}/{recipe}_{disc}_eta{eta_rho[0]}_rho{eta_rho[1]}_fractional_{file}.nc4"
+            f"{out_library}/{sector}/{pulse_year}/{mask}/{recipe}_{disc}_eta{eta_rho[0]}_rho{eta_rho[1]}_fractional_{file}.nc4"
         )
 
     # recover damage function as dollars instead of fraction
@@ -352,7 +353,7 @@ def weight_df(
 
     os.makedirs(f"{out_library}/{sector}/{pulse_year}/", exist_ok=True)
     dfs.to_netcdf(
-        f"{out_library}/{sector}/{pulse_year}/{recipe}_{disc}_eta{eta_rho[0]}_rho{eta_rho[1]}_{file}.nc4"
+        f"{out_library}/{sector}/{pulse_year}/{mask}/{recipe}_{disc}_eta{eta_rho[0]}_rho{eta_rho[1]}_{file}.nc4"
     )
 
 
@@ -368,6 +369,7 @@ def rff_damage_functions(
     runid_path,
     weights_path,
     pulse_year,
+    mask,
 ):
     """Wrapper function for `weight_df()`."""
 
@@ -405,6 +407,7 @@ def rff_damage_functions(
             weights=weights,
             factors=factors,
             pulse_year=pulse_year,
+            mask=mask,
         )
 
 


### PR DESCRIPTION
The `rff_damage_functions` function was previously reading SSP damage functions from a filepath that did not include the mask and saving out to a filepath not including the mask. This required manual moving of damage functions before and after this function was run. These changes should restore full automation to the input damage -> SCC pipeline.