### PR TITLE
Bump dask, distributed together -> 2023.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ xarray==2022.11.0
 pandas==2.0.3
 numpy==1.23.3
 matplotlib==3.7.2
-dask==2023.6.1
-distributed==2023.6.1
+dask==2023.7.0
+distributed==2023.7.0
 requests==2.31.0
 statsmodels==0.14.0
 pytest==7.4.0


### PR DESCRIPTION
Looks like dask and distributed pins need to be updated together. 

If this PR update passes CI it should replace failing dependabot PRs #91, #93.