### PR TITLE
Fix dask, distributed version bumps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ xarray==2022.11.0
 pandas==2.0.3
 numpy==1.23.3
 matplotlib==3.7.2
-dask==2023.7.0
-distributed==2023.7.0
+dask==2023.7.1
+distributed==2023.7.1
 requests==2.31.0
 statsmodels==0.14.0
 pytest==7.4.0


### PR DESCRIPTION
#109 and #108 are to upgrade packages failing because dask and distributed need to get bumped together. Otherwise, the environment fails to build.