### PR TITLE
Fix write-to-copy warning in process_rff_sample()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix write-to-copy warning in `process_rff_sample()`. ([PR #116](https://github.com/ClimateImpactLab/dscim/pull/116), [@brews](https://github.com/brews))
 - Fix bad release header links in CHANGELOG.md. ([PR #105](https://github.com/ClimateImpactLab/dscim/pull/105), [@brews](https://github.com/brews))
 - Fixed broken code quality checks in CI. Now using `ruff` instead of `flake8`. ([PR #107](https://github.com/ClimateImpactLab/dscim/pull/107), [@brews](https://github.com/brews))
 

--- a/src/dscim/utils/rff.py
+++ b/src/dscim/utils/rff.py
@@ -208,8 +208,8 @@ def process_rff_sample(i, rffpath, ssp_df, outdir, HEADER, **storage_options):
     ) * rff_df.GDP  # Adjust weight measurement from 2011 tp 2005 PPP USD
 
     # print(rff_df.iso[np.isnan(rff_df.weight)])
-    rff_df.weight[np.isnan(rff_df.weight)] = np.exp(
-        np.nanmean(np.log(rff_df.weight))
+    rff_df["weight"] = rff_df["weight"].fillna(
+        np.exp(np.nanmean(np.log(rff_df.weight)))
     )  # Fill missing value weights with sample mean
 
     out_df = solve_optimization(ssp_df, rff_df)


### PR DESCRIPTION
Close #114 

I think this avoids the problem. Test covering this passes but I don't think it tested the case if input data has NA/ NaNs so someone please tell me if I missed something.