### PR TITLE
Add naive list of package dependencies to pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add naive list of package dependencies to pyproject.toml.([@brews](https://github.com/brews))
+
 ### Changed
 
 - Dropped optional/unused dependencies `click`, `dask-jobqueue`, `geopandas`, `gurobipy`, `ipywidgets`, `seaborn`. ([PR #99](https://github.com/ClimateImpactLab/dscim/pull/99), [@brews](https://github.com/brews))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add naive list of package dependencies to pyproject.toml.([@brews](https://github.com/brews))
+- Add naive list of package dependencies to pyproject.toml.([PR #123](https://github.com/ClimateImpactLab/dscim/pull/123), [@brews](https://github.com/brews))
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,3 @@
-[build-system]
-requires = [
-    "setuptools>=62.0",
-    "wheel",
-    "setuptools_scm>=7.0",
-]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "dscim"
 description = "Data-Driven Spatial Climate Impact Model core component code"
@@ -42,6 +34,13 @@ Documentation = "https://github.com/ClimateImpactLab/dscim"
 Source = "https://github.com/ClimateImpactLab/dscim"
 "Bug Tracker" = "https://github.com/ClimateImpactLab/dscim/issues"
 
+[build-system]
+requires = [
+    "setuptools>=62.0",
+    "wheel",
+    "setuptools_scm>=7.0",
+]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 fallback_version = "999"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyarrow",
+    "pyyaml",
     "p_tqdm",
     "requests",
     "statsmodels",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "dask",
-    "distributed",
+    "dask[array, distributed]",
     "impactlab-tools",
     "matplotlib",
     "netcdf4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[build-system]
+requires = [
+    "setuptools>=62.0",
+    "wheel",
+    "setuptools_scm>=7.0",
+]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "dscim"
 description = "Data-Driven Spatial Climate Impact Model core component code"
@@ -11,6 +19,22 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 requires-python = ">=3.8"
+dependencies = [
+    "dask",
+    "distributed",
+    "impactlab-tools",
+    "matplotlib",
+    "netcdf4",
+    "h5netcdf",
+    "numpy",
+    "pandas",
+    "pyarrow",
+    "p_tqdm",
+    "requests",
+    "statsmodels",
+    "xarray",
+    "zarr",
+]
 
 [project.urls]
 Homepage = "https://github.com/ClimateImpactLab/dscim"
@@ -18,13 +42,6 @@ Documentation = "https://github.com/ClimateImpactLab/dscim"
 Source = "https://github.com/ClimateImpactLab/dscim"
 "Bug Tracker" = "https://github.com/ClimateImpactLab/dscim/issues"
 
-[build-system]
-requires = [
-    "setuptools>=62.0",
-    "wheel",
-    "setuptools_scm>=7.0",
-]
-build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 fallback_version = "999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# This is used to build the CI test environment and so Github can track dependencies.
 xarray==2022.11.0
 pandas==2.0.3
 numpy==1.23.3


### PR DESCRIPTION
This PR adds a list of package dependencies so people have an idea of what's required to run things.

Basically, this takes the packages in requirement.txt and puts them into pyproject.toml, without version pins.

I have a feeling that some of these are not really hard required dependencies. Some might be optional, so we might want to tweak these a bit and make some optional dependencies or "features". Like a "viz" section that installs stuff required to do graphics and plots -- then we can make those packages optional. "io" might be another good one because it looks like there are a couple heavy packages for reading and writing different file formats and I'm not sure if these are always required. Anyways, that might be a task for another PR.

Close #102