### PR TITLE
Bump dask, distributed -> 2023.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ xarray==2022.11.0
 pandas==2.0.3
 numpy==1.23.3
 matplotlib==3.7.2
-dask==2023.7.1
-distributed==2023.7.1
+dask==2023.8.0
+distributed==2023.8.0
 requests==2.31.0
 statsmodels==0.14.0
 pytest==7.4.0


### PR DESCRIPTION
I'm getting tired of doing these.

Fixes to #124 and #125 breaking because lately dask and distributed need to get bumped together.