### PR TITLE
Fix dependabot failing dask, distributed bumps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ xarray==2022.11.0
 pandas==2.0.3
 numpy==1.23.3
 matplotlib==3.7.2
-dask==2023.8.0
-distributed==2023.8.0
+dask[array, distributed]==2023.8.0
 requests==2.31.0
 statsmodels==0.14.0
 pytest==7.4.0


### PR DESCRIPTION
Minor fix to how we format requirements.txt so we don't need to do workarounds like PR #126 every time dependabot wants to bump dask. Basically, the additional dask packages get installed as extensions of the dask package install, rather than entirely separate packages.