### PR TITLE
Fix DeprecationWarning on import, switch to hatchling build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Auto-generated during builds
+/src/dscim/_version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dropped optional/unused dependencies `click`, `dask-jobqueue`, `geopandas`, `gurobipy`, `ipywidgets`, `seaborn`. ([PR #99](https://github.com/ClimateImpactLab/dscim/pull/99), [@brews](https://github.com/brews))
+- Switch build system from `setuptools` to `hatchling`. ([PR #128](https://github.com/ClimateImpactLab/dscim/pull/128), [@brews](https://github.com/brews))
 
 ### Fixed
 
+- Fix DeprecationWarning on import. ([PR #128](https://github.com/ClimateImpactLab/dscim/pull/128), [@brews](https://github.com/brews))
 - Fix write-to-copy warning in `process_rff_sample()`. ([PR #116](https://github.com/ClimateImpactLab/dscim/pull/116), [@brews](https://github.com/brews))
 - Fix bad release header links in CHANGELOG.md. ([PR #105](https://github.com/ClimateImpactLab/dscim/pull/105), [@brews](https://github.com/brews))
 - Fixed broken code quality checks in CI. Now using `ruff` instead of `flake8`. ([PR #107](https://github.com/ClimateImpactLab/dscim/pull/107), [@brews](https://github.com/brews))

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-prune tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,22 @@ Source = "https://github.com/ClimateImpactLab/dscim"
 "Bug Tracker" = "https://github.com/ClimateImpactLab/dscim/issues"
 
 [build-system]
-requires = [
-    "setuptools>=62.0",
-    "wheel",
-    "setuptools_scm>=7.0",
-]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
-[tool.setuptools_scm]
-fallback_version = "999"
+[tool.hatch.build.targets.sdist]
+# Exclude /tests: included test data too large to ship to PyPI.
+exclude = [
+    "/.github",
+    "/tests",
+]
+
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "999"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/dscim/_version.py"
 
 [tool.ruff]
 exclude = [

--- a/src/dscim/__init__.py
+++ b/src/dscim/__init__.py
@@ -8,6 +8,7 @@ import inspect
 
 from datetime import datetime
 from itertools import product
+from dscim._version import __version__  # noqa: F401
 from dscim.menu.simple_storage import Climate, EconVars
 from dscim.menu.main_recipe import MainRecipe
 
@@ -25,7 +26,6 @@ MENU_OPTIONS = {
 
 # Make attributes stick
 xarray.set_options(keep_attrs=True)
-
 
 # ERROR = 40, WARNING = 30, INFO = 20, DEBUG = 10
 LOG_LEVEL = int(os.environ.get("LOG_LEVEL", logging.INFO))

--- a/src/dscim/__init__.py
+++ b/src/dscim/__init__.py
@@ -8,7 +8,6 @@ import inspect
 
 from datetime import datetime
 from itertools import product
-import pkg_resources
 from dscim.menu.simple_storage import Climate, EconVars
 from dscim.menu.main_recipe import MainRecipe
 
@@ -24,17 +23,9 @@ MENU_OPTIONS = {
     "equity": dscim.menu.equity.EquityRecipe,
 }
 
-
 # Make attributes stick
 xarray.set_options(keep_attrs=True)
 
-# courtesy of https://github.com/pydata/xarray/blob/main/xarray/__init__.py#L32
-try:
-    __version__ = pkg_resources.get_distribution("dscim").version
-except Exception:
-    # Local copy or not installed with setuptools.
-    # Disable minimum version checks on downstream libraries.
-    __version__ = "999"
 
 # ERROR = 40, WARNING = 30, INFO = 20, DEBUG = 10
 LOG_LEVEL = int(os.environ.get("LOG_LEVEL", logging.INFO))


### PR DESCRIPTION
This fixes the DeprecationWarning about the `pkg_resources` package when `dscim` is imported. The warning comes from the system used to get the package version into `dscim.__version__`. With this fix, the version info is written to `src/dscim/_version.py` whenever the package is built by hatchling, and `src/dscim/__init__.py.` does `from dscim._version import __version__` and that's it.

This switches the build system from `setuptools` to `hatchling`. This is an internal change. Generally, people shouldn't notice this change. We prob would have switched build systems at some point anyways so might as well do it here.

Close #112 