### PR TITLE
Fixes broken codecov in CI

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -67,3 +67,5 @@ jobs:
           pytest -v --cov dscim --cov-report term-missing --cov-report xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The codecov github action we use in CI is now v4, which requires CODECOV_TOKEN to function. This PR updates the CI action to use the CODECOV_TOKEN secret to get things working again.

Again, this was just a bug in CI.