### PR TITLE
Only run pytests/black when dscim src is changed

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -3,6 +3,9 @@ name: Python package
 on:
   pull_request:
   push:
+    paths:
+      - src/
+      - tests/
     branches:
       - main
 

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -2,6 +2,9 @@ name: Python package
 
 on:
   pull_request:
+      paths:
+      - src/
+      - tests/
   push:
     paths:
       - src/


### PR DESCRIPTION
It's driving me a little crazy that the pytests run when I make a change only in the readme/changelog. Especially with the upcoming documentation addition, I think this'll streamline the workflow nicely. My goal with this PR is to only run the pytests when making a change to code. 

see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore