### PR TITLE
Drop 'black' for 'ruff format' in CI

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -32,12 +32,12 @@ jobs:
       - name: Install package
         run: |
           pip install . --no-deps
-      - name: Format check with black
+      - name: Format check with ruff
         run: |
-          black --check .
-      - name: Format ruff check
+          ruff format . --diff
+      - name: Lint check with ruff
         run: |
-          ruff check .
+          ruff check . --output-format=github
 
   test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,10 @@ exclude = [
 
 [tool.ruff.lint]
 # E402: module level import not at top of file
+# E501: line too long
 ignore = [
     "E402",
+    "E501",
 ]
 select = [
     # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,11 @@ exclude = [
     ".eggs",
     "docs",
 ]
+
+[tool.ruff.lint]
 # E402: module level import not at top of file
-# E501: line too long - let black worry about that
 ignore = [
     "E402",
-    "E501",
 ]
 select = [
     # Pyflakes

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ statsmodels==0.14.2
 pytest==8.2.1
 pytest-cov==5.0.0
 zarr==2.18.2
-black==24.4.2
 ruff==0.4.5
 netcdf4==1.6.5
 h5netcdf==1.3.0

--- a/src/dscim/utils/rff.py
+++ b/src/dscim/utils/rff.py
@@ -477,9 +477,7 @@ def aggregate_rff_weights(
     # describe and save file
     reweighted = reweighted.to_dataset()
     reweighted.attrs["version"] = 3
-    reweighted.attrs[
-        "description"
-    ] = """
+    reweighted.attrs["description"] = """
     This set of emulator weights is generated using this script:
     dscim/dscim/utils/rff.py -> aggregate_rff_weights
     It cleans and aggregates the emulator weights csvs, linearly interpolates them between 5 year intervals, reweights them to sum to 1, and converts to ncdf4 format.
@@ -495,9 +493,7 @@ def aggregate_rff_weights(
     # describe and save file
     error_concatenated = error_concatenated.to_dataset()
     error_concatenated.attrs["version"] = 3
-    error_concatenated.attrs[
-        "description"
-    ] = """
+    error_concatenated.attrs["description"] = """
     This set of emulator weight errors is generated using this script:
     dscim/dscim/preprocessing/rff/aggregate_rff_weights.py
     It cleans and aggregates the emulator weights csvs for error rows only, and converts to ncdf4 format.

--- a/src/dscim/utils/utils.py
+++ b/src/dscim/utils/utils.py
@@ -521,9 +521,7 @@ def compute_damages(anomaly, betas, formula):
             "gmsl:anomaly"
         ] * anomaly.temperature * anomaly.gmsl + betas[
             "gmsl:np.power(anomaly, 2)"
-        ] * anomaly.gmsl * np.power(
-            anomaly.temperature, 2
-        )
+        ] * anomaly.gmsl * np.power(anomaly.temperature, 2)
     elif (
         formula
         == "damages ~ -1 + anomaly + np.power(anomaly, 2) + gmsl + np.power(gmsl, 2)"


### PR DESCRIPTION
This completes replacing `black` with `ruff` for linting and format checks in CI and dropping `black` entirely as a requirement from the package.

Few people will notice the change unless they're looking at PRs and results from CI.

Ruff asked for a minor code clean up, so that's in here, too.