### PR TITLE
Minor style cleanup, using f-strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Python version for running automated tests in CI upgraded from Python 3.10 to 3.12 ([PR #270](https://github.com/ClimateImpactLab/dscim/pull/270), [@brews](https://github.com/brews)).
 
+### Fixed
+
+- Minor code cleanup. Switch old %-string formatting to use f-strings ([PR #351](https://github.com/ClimateImpactLab/dscim/pull/351), [@brews](https://github.com/brews)).
+
 ### Removed
 
 - Removed [`preprocessing/climate`](https://github.com/ClimateImpactLab/dscim/tree/25dfb39637d5716662a3ec636028d5066ddb10bb/src/dscim/preprocessing/climate) and [`preprocessing/misc`](https://github.com/ClimateImpactLab/dscim/tree/25dfb39637d5716662a3ec636028d5066ddb10bb/src/dscim/preprocessing/misc) subpackages. ([PR #249](https://github.com/ClimateImpactLab/dscim/pull/249), [@JMGilbert](https://github.com/JMGilbert))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ statsmodels==0.14.4
 pytest==8.3.4
 pytest-cov==6.0.0
 zarr==2.18.3
-ruff==0.7.3
+ruff==0.8.1
 netcdf4==1.7.2
 h5netcdf==1.4.1
 impactlab-tools==0.6.0

--- a/src/dscim/utils/rff.py
+++ b/src/dscim/utils/rff.py
@@ -160,9 +160,9 @@ def process_ssp_sample(ssppath):
     ssp_df = pd.read_csv(ssppath, skiprows=11)
     ssp_df = ssp_df[ssp_df.year >= 2010]
     ssp_df["loginc"] = np.log(ssp_df.value)
-    ssp_df["isoyear"] = ssp_df.apply(lambda row: "%s:%d" % (row.iso, row.year), axis=1)
+    ssp_df["isoyear"] = ssp_df.apply(lambda row: f"{row.iso}:{row.year:d}", axis=1)
     ssp_df["yearscen"] = ssp_df.apply(
-        lambda row: "%d:%s/%s" % (row.year, row.model, row.scenario), axis=1
+        lambda row: f"{row.year:d}:{row.model}/{row.scenario}", axis=1
     )
 
     return ssp_df
@@ -176,7 +176,7 @@ def process_rff_sample(i, rffpath, ssp_df, outdir, HEADER, **storage_options):
     increments for a single RFF-SP
     """
 
-    read_feather = os.path.join(rffpath, "run_%d.feather" % i)
+    read_feather = os.path.join(rffpath, f"run_{i:d}.feather")
     rff_raw = pd.read_feather(read_feather)
     rff_raw.rename(columns={"Year": "year", "Country": "iso"}, inplace=True)
 
@@ -199,7 +199,7 @@ def process_rff_sample(i, rffpath, ssp_df, outdir, HEADER, **storage_options):
         rff_df = pd.concat((rff_df, all_year_df))
 
     rff_df["loginc"] = np.log(rff_df.value)
-    rff_df["isoyear"] = rff_df.apply(lambda row: "%s:%d" % (row.iso, row.year), axis=1)
+    rff_df["isoyear"] = rff_df.apply(lambda row: f"{row.iso}:{row.year:d}", axis=1)
 
     rff_df = pd.merge(rff_df, rff_raw, on=["year", "iso"], how="left")
 


### PR DESCRIPTION
Minor update converting % string formatting to use newer recommended f-string formatting. It's now a best practice. Should be easier to read.

This should have no change on package functionality.

This also bumps ruff to 0.8.x, which recommended the change when Dependabot tried to bump it in #348.