### PR TITLE
Remove zarr error

### DIFF
--- a/src/dscim/preprocessing/input_damages.py
+++ b/src/dscim/preprocessing/input_damages.py
@@ -14,7 +14,6 @@ from itertools import product
 from functools import partial
 from p_tqdm import p_map, p_umap
 from dscim.menu.simple_storage import EconVars
-from zarr.errors import GroupNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -835,11 +834,7 @@ def coastal_inputs(
     adapt_type,
     vsl_valuation=None,
 ):
-    try:
-        d = xr.open_zarr(f"{path}/coastal_damages_{version}.zarr")
-    except GroupNotFoundError:
-        print(f"Zarr not found: {path}/coastal_damages_{version}.zarr")
-        exit()
+    d = xr.open_zarr(f"{path}/coastal_damages_{version}.zarr")
 
     if "vsl_valuation" in d.coords:
         if vsl_valuation is None:


### PR DESCRIPTION
It looks like undocumented in zarr 3.0.0 was the removal of the `zarr.errors.GroupNotFoundError`. Looking at their PRs, it looks like it will be imminently added back. I think it makes sense for the zarr package to take care of the error throwing so I am removing it from our function.